### PR TITLE
Allow Rails4, implement compound keys in models

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ can then be used for filtering results or ordering.
       # * the by_author view above
       # * def find_by_author(author); end
       index_view :author
+      
+      # You can make compound keys by passing an array to :emit_key
+      # this allow to query by read/unread comments
+      view :by_read, emit_key: [:user_id, :read]
+      # this allow to query by view_count
+      view :by_view_count, emit_key: [:user_id, :view_count]
+       
+      
+      
 
       validates_presence_of :author, :body
     end
@@ -109,6 +118,13 @@ can then be used for filtering results or ordering.
 You can use `Comment.find_by_author('name')` to obtain all the comments by
 a particular author. The same thing, using the view directly would be:
 `Comment.by_author(key: 'name')`
+
+When using a compound key, the usage is the same, you just give the full key : 
+`Comment.by_read(key: '["'+user_id+'",false]')` # gives all unread comments for one particular user
+or even a range
+`Comment.by_view_count(startkey: '["'+user_id+'",10]', endkey: '["'+user_id+'",20]')` # gives all comments that have been seen more than 10 times but less than 20
+
+Compound keys allows to decide the order of the results, and you can reverse that by passing `descending: true`
 
 ## Associations and Indexes
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,18 @@ a particular author. The same thing, using the view directly would be:
 `Comment.by_author(key: 'name')`
 
 When using a compound key, the usage is the same, you just give the full key : 
-`Comment.by_read(key: '["'+user_id+'",false]')` # gives all unread comments for one particular user
-or even a range
-`Comment.by_view_count(startkey: '["'+user_id+'",10]', endkey: '["'+user_id+'",20]')` # gives all comments that have been seen more than 10 times but less than 20
 
-Compound keys allows to decide the order of the results, and you can reverse that by passing `descending: true`
+```ruby
+   Comment.by_read(key: '["'+user_id+'",false]') # gives all unread comments for one particular user
+   
+   # or even a range !
+   
+   Comment.by_view_count(startkey: '["'+user_id+'",10]', endkey: '["'+user_id+'",20]') # gives all comments that have been seen more than 10 times but less than 20
+```
+
+Check this couchbase help page to learn more on what's possible with compound keys : https://developer.couchbase.com/documentation/server/3.x/admin/Views/views-translateSQL.html
+
+Ex : Compound keys allows to decide the order of the results, and you can reverse it by passing `descending: true`
 
 ## Associations and Indexes
 

--- a/couchbase-orm.gemspec
+++ b/couchbase-orm.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
     gem.require_paths = ["lib"]
 
     gem.add_runtime_dependency     'libcouchbase', '~> 0.1'
-    gem.add_runtime_dependency     'activemodel',  '~> 5.0'
+    gem.add_runtime_dependency     'activemodel',  '~> 4.0'
     gem.add_runtime_dependency     'radix',        '~> 2.2' # converting numbers to and from any base
 
     gem.add_development_dependency 'rake',         '~> 11.2'

--- a/lib/couchbase-orm/views.rb
+++ b/lib/couchbase-orm/views.rb
@@ -42,7 +42,7 @@ module CouchbaseOrm
                         method_opts[:map] = <<-EMAP
 function(doc) {
     if (doc.type === "{{design_document}}") {
-        emit([#{emit_key.map{|key| "doc."+key}.join(',')}], null);
+        emit([#{emit_key.map{|key| "doc."+key.to_s}.join(',')}], null);
     }
 }
 EMAP


### PR DESCRIPTION
This is the orm side of this PR : https://github.com/cotag/libcouchbase/pull/4

Which allow to use the new compound keys added in libcouchbase.